### PR TITLE
Add support for "Last Will" messages

### DIFF
--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -465,7 +465,7 @@ Subscribes to the given topic(s) and registers the callbacks. Note that only
 the first matching handler will be called for every message, even if filter
 patterns overlap.
 
-=head2 unsubscribe(topic[, topic, ...]) {
+=head2 unsubscribe(topic[, topic, ...])
 
 Unsubscribes from the given topic(s) and unregisters the corresponding
 callbacks. The given topics must exactly match topics that were previously

--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -475,7 +475,7 @@ colon. The functions C<publish> and C<retain> will be exported.
 
 =head2 Object oriented interface
 
-=head3 new(server[, sockopts])
+=head3 new(server[, sockopts][, will_topic][, will_message][, will_retain])
 
 Specify the server (possibly with a colon and port number) to the constructor,
 C<< Net::MQTT::Simple->new >>. The socket is disconnected when the object goes
@@ -483,6 +483,17 @@ out of scope.
 
 Optionally, a reference to a hash of socket options can be passed. Options
 specified in this hash are passed on to the socket constructor.
+
+Additionally, an optional "Last Will" topic, message, and retain flag for the
+message may be registered with the server on connection. This message will be
+published if the script exits without callng C<disconnect>.
+
+=head1 DISCONNECTING GRACEFULLY
+
+=head2 disconnect
+
+Performs a graceful disconnect, which ensures that the server does NOT send
+the registered "Last Will" message.
 
 =head1 PUBLISHING MESSAGES
 
@@ -575,11 +586,6 @@ indicate that it has already been sent before.
 =item Authentication
 
 No username and password are sent to the server.
-
-=item Last will
-
-The server won't publish a "last will" message on behalf of us when our
-connection's gone.
 
 =item Large data
 

--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -391,6 +391,16 @@ sub tick {
     return !! $self->{socket};
 }
 
+sub disconnect {
+    my ($self) = @_;
+    return if !exists ($self->{socket});
+    if ($self->{socket}->connected) {
+        $self->_send (pack (" C x", 0xe0));
+    }
+
+    delete $self->{socket};
+}
+
 1;
 
 __END__


### PR DESCRIPTION
- Adds  optional support for "Last Will" messages.  The topic, message and retain flag may optionally be passed to new.
- Adds an additional "disconnect" method so that graceful disconnects can be performed, which suppresses the publishing of the "Last Will" message from the server.
- Updated the documentation to reflect the additions.


