### PR TITLE
Fix removal of callback on unsubscribe

### DIFF
--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -392,8 +392,9 @@ sub unsubscribe {
     $self->_send_unsubscribe(@topics);
 
     my $cb = $self->{callbacks};
-    @$cb = grep $_->{topic} ne $_, @$cb
-        for @topics;
+    for my $topic ( @topics ) {
+      @$cb = grep {$_->{topic} ne $topic} @$cb;
+    }
 
     delete @{ $self->{sub} }{ @topics };
 }


### PR DESCRIPTION
Callbacks are not removed properly on unsubscribe, any future subscription to the same topic pushes a new callback onto the list, and only the first will be called.

$_ was used twice in the same statement with a different intention on each one.