### PR TITLE
Enable separate client ID per instance of the object

### DIFF
--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -27,8 +27,8 @@ sub _default_port { 1883 }
 sub _socket_error { "$@" }
 sub _secure { 0 }
 
-my $random_id = join "", map chr 65 + int rand 26, 1 .. 10;
-sub _client_identifier { "Net::MQTT::Simple[$random_id]" }
+
+sub _client_identifier { my ($class) = @_; return "Net::MQTT::Simple[" . $class->{random_id} . "]"; }
 
 # Carp might not be available either.
 sub _croak {
@@ -76,10 +76,14 @@ sub new {
     # Add port for bare IPv4 address or bracketed IPv6 address
     $server .= ":$port" if $server !~ /:/ or $server =~ /^\[.*\]$/;
 
+	# Create a random ID for the instance of the object
+	my $random_id = join "", map chr 65 + int rand 26, 1 .. 10;
+	
     return bless {
         server       => $server,
         last_connect => 0,
         sockopts     => $sockopts // {},
+        random_id    => $random_id
     }, $class;
 }
 


### PR DESCRIPTION
The existing codebase has an issue in which it shares the instance ID between multiple
objects that are instantiated from the same script. This causes confusion at the broker and dropped transmissions when the objects send alternating data to the same broker.

Example code to trigger/test this:

```

use strict;
use warnings;

use Net::MQTT::Simple;

my $client1 = Net::MQTT::Simple->new('broker.local');
my $client2 = Net::MQTT::Simple->new('broker.locall');

print "Client1: " . $client1->_client_identifier() . "\n";
print "Client2: " . $client2->_client_identifier() . "\n";

```

With the update in this commit the client identifier is stored per object and results
in a separate ID per object.