### PR TITLE
Chunk _send data into $READ_BYTES bytes.

### DIFF
--- a/lib/Net/MQTT/Simple.pm
+++ b/lib/Net/MQTT/Simple.pm
@@ -192,6 +192,11 @@ sub _send {
 
     my $socket = $self->{socket} or return;
 
+    while (my $chunk = substr $data, 0, $READ_BYTES, "") {
+        syswrite $socket, $chunk
+            or $self->_drop_connection;  # reconnect on next message
+    }
+
     syswrite $socket, $data
         or $self->_drop_connection;  # reconnect on next message
 


### PR DESCRIPTION
When sending messages longer than 16Kb, we end up truncating the message, which ends up causing a protocol error and having the client disconnected.

This change chunks the sending data into $READ_BYTES chunks.

Fixes #18